### PR TITLE
Other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ you like pineapples).
 
 ## Project status
 
-HTM.jl is a small (~300 lines of code) open-source Julia project.
+HTM.jl is a small (<400 lines of code) open-source Julia project.
 It was once called JSX.jl.
 Its main goal is to create a fully-featured, backend-agnostic (any library
 that produces HTML elements can be used as a backend) alternative to the

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ and [Hypertext Literal](https://github.com/observablehq/htl):
 - Self-closing tags: `htm"<div />"`
 - Multiple root elements (fragments): `htm"<div /><div />"`
 - Boolean attributes: `htm"<div draggable />"` or `htm"<div draggable=$(true) />"`
-- HTML's optional quotes: `htm"<div class=fruit></div>"`
+- HTML optional quotes: `htm"<div class=fruit></div>"`
 - Styles: `htm"<div style=$(style)></div>"`
 - Universal end-tags: `htm"<div>🍍<//>"`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ and [Hypertext Literal](https://github.com/observablehq/htl):
 - Spread attributes: `htm"<div $(attrs)></div>"`
 - Self-closing tags: `htm"<div />"`
 - Multiple root elements (fragments): `htm"<div /><div />"`
-- Short circuit rendering: `htm"<div>$(hidefruit || \"🍍\")</div>"`
+- Short circuit rendering: `htm"<div>$(hidefruit || '🍍')</div>"`
 - Boolean attributes: `htm"<div draggable />"` or `htm"<div draggable=$(true) />"`
 - HTML optional quotes: `htm"<div class=fruit></div>"`
 - Styles: `htm"<div style=$(style)></div>"`

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ and [Hypertext Literal](https://github.com/observablehq/htl):
 - Spread attributes: `htm"<div $(attrs)></div>"`
 - Self-closing tags: `htm"<div />"`
 - Multiple root elements (fragments): `htm"<div /><div />"`
+- Short circuit rendering: `htm"<div>$(hidefruit || \"🍍\")</div>"`
 - Boolean attributes: `htm"<div draggable />"` or `htm"<div draggable=$(true) />"`
 - HTML optional quotes: `htm"<div class=fruit></div>"`
 - Styles: `htm"<div style=$(style)></div>"`

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ and [Hypertext Literal](https://github.com/observablehq/htl):
 - HTML optional quotes: `htm"<div class=fruit></div>"`
 - Styles: `htm"<div style=$(style)></div>"`
 - Universal end-tags: `htm"<div>🍍<//>"`
+- HTML-style comments: `htm"<div><!-- 🍌 --></div>"`
 
 Furthermore, the components can be constructed using
 [Julia's display system](https://docs.julialang.org/en/v1/base/io-network/#Multimedia-I/O):

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -36,6 +36,16 @@ suite[raw"<div /><div />"]["direct"] = @benchmarkable (m("div"), m("div"))
 suite[raw"<div /><div />"]["create"] = @benchmarkable htm"<div /><div />"
 suite[raw"<div /><div />"]["parser"] = @benchmarkable HTM.parse(raw"<div /><div />")
 
+suite[raw"<div>$(hidefruit || '🍍')</div>"] = BenchmarkGroup(["short-circuit", "child-interps", "has-children", "end-tags"],
+    "direct" => BenchmarkGroup([]),
+    "create" => BenchmarkGroup([]),
+    "parser" => BenchmarkGroup([]),
+)
+hidefruit = false
+suite[raw"<div>$(hidefruit || '🍍')</div>"]["direct"] = @benchmarkable m("div", hidefruit || '🍍')
+suite[raw"<div>$(hidefruit || '🍍')</div>"]["create"] = @benchmarkable htm"<div>$(hidefruit || '🍍')</div>"
+suite[raw"<div>$(hidefruit || '🍍')</div>"]["parser"] = @benchmarkable HTM.parse(raw"<div>$(hidefruit || '🍍')</div>")
+
 suite[raw"<div draggable />"] = BenchmarkGroup(["optional-attrs", "self-closing-tags"],
     "direct" => BenchmarkGroup([]),
     "create" => BenchmarkGroup([]),
@@ -83,27 +93,16 @@ suite[raw"<div>🍍<//>"]["direct"] = @benchmarkable m("div", "🍍")
 suite[raw"<div>🍍<//>"]["create"] = @benchmarkable htm"<div>🍍<//>"
 suite[raw"<div>🍍<//>"]["parser"] = @benchmarkable HTM.parse(raw"<div>🍍<//>")
 
+suite[raw"<div><!-- 🍌 --></div>"] = BenchmarkGroup(["html-comment", "end-tags"],
+    "direct" => BenchmarkGroup([]),
+    "create" => BenchmarkGroup([]),
+    "parser" => BenchmarkGroup([]),
+)
+suite[raw"<div><!-- 🍌 --></div>"]["direct"] = @benchmarkable m("div")
+suite[raw"<div><!-- 🍌 --></div>"]["create"] = @benchmarkable htm"<div><!-- 🍌 --></div>"
+suite[raw"<div><!-- 🍌 --></div>"]["parser"] = @benchmarkable HTM.parse(raw"<div><!-- 🍌 --></div>")
+
 # --- Others ---
-
-suite[raw"<div id=$(id)>$(content)</div>"] = BenchmarkGroup(["attr-interps", "child-interps", "optional-quotes", "end-tags"],
-    "direct" => BenchmarkGroup([]),
-    "create" => BenchmarkGroup([]),
-    "parser" => BenchmarkGroup([]),
-)
-id = 23
-content = "Hello HTM.jl🍍!"
-suite[raw"<div id=$(id)>$(content)</div>"]["direct"] = @benchmarkable m("div", id=id, content)
-suite[raw"<div id=$(id)>$(content)</div>"]["create"] = @benchmarkable htm"<div id=$(id)>$(content)</div>"
-suite[raw"<div id=$(id)>$(content)</div>"]["parser"] = @benchmarkable HTM.parse(raw"<div id=$(id)>$(content)</div>")
-
-suite[raw"<div>🍍</div>"] = BenchmarkGroup(["has-children", "end-tags"],
-    "direct" => BenchmarkGroup([]),
-    "create" => BenchmarkGroup([]),
-    "parser" => BenchmarkGroup([]),
-)
-suite[raw"<div>🍍</div>"]["direct"] = @benchmarkable m("div", "🍍")
-suite[raw"<div>🍍</div>"]["create"] = @benchmarkable htm"<div>🍍</div>"
-suite[raw"<div>🍍</div>"]["parser"] = @benchmarkable HTM.parse(raw"<div>🍍</div>")
 
 suite[raw"<div class=fruit>🍍</div>"] = BenchmarkGroup(["optional-quotes", "has-attrs", "has-children", "end-tags"],
     "direct" => BenchmarkGroup([]),
@@ -113,6 +112,17 @@ suite[raw"<div class=fruit>🍍</div>"] = BenchmarkGroup(["optional-quotes", "ha
 suite[raw"<div class=fruit>🍍</div>"]["direct"] = @benchmarkable m("div", class="fruit", "🍍")
 suite[raw"<div class=fruit>🍍</div>"]["create"] = @benchmarkable htm"<div class=fruit>🍍</div>"
 suite[raw"<div class=fruit>🍍</div>"]["parser"] = @benchmarkable HTM.parse(raw"<div class=fruit>🍍</div>")
+
+suite[raw"<div id=$(id)>$(content)</div>"] = BenchmarkGroup(["attr-interps", "child-interps", "has-children", "optional-quotes", "end-tags"],
+    "direct" => BenchmarkGroup([]),
+    "create" => BenchmarkGroup([]),
+    "parser" => BenchmarkGroup([]),
+)
+id = 23
+content = "Hello HTM.jl🍍!"
+suite[raw"<div id=$(id)>$(content)</div>"]["direct"] = @benchmarkable m("div", id=id, content)
+suite[raw"<div id=$(id)>$(content)</div>"]["create"] = @benchmarkable htm"<div id=$(id)>$(content)</div>"
+suite[raw"<div id=$(id)>$(content)</div>"]["parser"] = @benchmarkable HTM.parse(raw"<div id=$(id)>$(content)</div>")
 
 # TODO: component concept through Julia's display system
 # TODO: some other ideas from:

--- a/docs/src/autodocs.md
+++ b/docs/src/autodocs.md
@@ -2,13 +2,15 @@
 CurrentModule = HTM
 ```
 
-# Docstrings
-
-```@autodocs
-Modules = [HTM]
-```
+# Internals
 
 ## Index
 
 ```@index
+```
+
+## Docstrings
+
+```@autodocs
+Modules = [HTM]
 ```

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -26,7 +26,7 @@ element tree:
 
 ```jldoctest
 julia> @macroexpand htm"<span />"
-:((HTM.create_element)((HTM.processtag)(["span"]), Dict{String, Any}(), Any[]))
+:((HTM.create_element)((HTM.rendertag)(["span"]), Pair{String, Any}[], Any[]))
 ```
 
 The overhead is small when compared to using Hyperscript.jl directly:

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -26,7 +26,7 @@ element tree:
 
 ```jldoctest
 julia> @macroexpand htm"<span />"
-:((HTM.create_element)((HTM.rendertag)(["span"]), Pair{String, Any}[], Any[]))
+:((HTM.create_element)((HTM.create_tag)("span"), Pair{Symbol, Any}[], Any[]))
 ```
 
 The overhead is small when compared to using Hyperscript.jl directly:

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -26,7 +26,7 @@ element tree:
 
 ```jldoctest
 julia> @macroexpand htm"<span />"
-:(create_element(processtag(["span"]), Dict{String, Any}(), Any[]))
+:((HTM.create_element)((HTM.processtag)(["span"]), Dict{String, Any}(), Any[]))
 ```
 
 The overhead is small when compared to using Hyperscript.jl directly:

--- a/docs/src/related.md
+++ b/docs/src/related.md
@@ -10,7 +10,3 @@ The following open-source packages are **possible backends** (not thoroughly tes
 - [Hyperscript.jl](https://github.com/yurivish/Hyperscript.jl) is the default backend
 - [WebIO.jl](https://github.com/JuliaGizmos/WebIO.jl)
 - [Hiccup.jl](https://github.com/JunoLab/Hiccup.jl)
-
-The following open-source packages **extend and play nice** with HTM.jl:
-
-- [JSExpr.jl](https://github.com/JuliaGizmos/JSExpr.jl) offer an elegant way of writing JavaScript.

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -74,7 +74,6 @@ using HTM  # hide
 using Plots
 
 default(size=(250, 250))  # hide
-# Graph simplified from <https://www.desmos.com/calculator/eds5nef5cj>.
 p = begin
     plot!(θ -> 30.4 / (2 + sin(θ)) - 9.5, 0, 2π, color=:brown, proj=:polar, legend=nothing)
     for (a, b) in zip([-4  , 3  ,  9.6, 16.2, 22.7, 29.2, 35.7],
@@ -87,6 +86,7 @@ end
 pineapple = "https://upload.wikimedia.org/wikipedia/commons/thumb/7/74/%E0%B4%95%E0%B5%88%E0%B4%A4%E0%B4%9A%E0%B5%8D%E0%B4%9A%E0%B4%95%E0%B5%8D%E0%B4%95.jpg/800px-%E0%B4%95%E0%B5%88%E0%B4%A4%E0%B4%9A%E0%B5%8D%E0%B4%9A%E0%B4%95%E0%B5%8D%E0%B4%95.jpg"  # hide
 🍍() = htm"<img src=$(pineapple) />"  # hide
 htm"""<div style="display: flex">
+    <!-- Graph simplified from <https://www.desmos.com/calculator/eds5nef5cj>. -->
     <div style="transform: rotate(5deg)">$(p)</div>
     <div style="max-width: 50%">$(🍍())</div>
 </div>"""
@@ -169,7 +169,6 @@ That is useful for mapping data to content via
 using HTM  # hide
 using Colors
 
-# Example taken from <https://observablehq.com/@observablehq/htl>.
 rows = map(enumerate(colormap("Oranges", 5))) do (i, color)
     htm"""<tr>
         <td>$(i)</td>
@@ -183,6 +182,7 @@ header = htm"""<tr>
 </tr>"""
 
 htm"""<table>
+    <!-- Example inspired from <https://observablehq.com/@observablehq/htl>. -->
     <caption>Five shades of 🍍</caption>
     <thead>$(header)</thead>
     <tbody>$(rows)</tbody>

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -102,6 +102,24 @@ orange(text) = htm"<span style=\"background: orange\">$(text)</span>"
 htm"<p><strong>This is $(orange(\"really\")) important.</strong></p>"
 ```
 
+You can even use
+[`@html_str`](https://docs.julialang.org/en/v1/base/strings/#Base.Docs.@html_str)
+(from `Base.Docs`)
+and [`@md_str`](https://docs.julialang.org/en/v1/stdlib/Markdown/)
+from the [standard library](https://docs.julialang.org/en/v1/):
+
+```jldoctest
+julia> htm"<div>$(md\"# 🍍\")</div>"
+<div><p class="markdown"><h1> 🍍</h1></p></div>
+
+julia> htm"<p>🍍$(html\"&nbsp;\")🍌</p>"
+<p>🍍&nbsp;🍌</p>
+```
+
+!!! info
+    Using `@html_str` from the standard library as above is the recommended
+    strategy for bypassing escaping of HTML entities.
+
 Contrary to
 [JSX](https://reactjs.org/docs/jsx-in-depth.html#choosing-the-type-at-runtime)
 or

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -50,7 +50,7 @@ true
 ```
 
 Multiple top-level elements
-(["document fragments"](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment),
+(["document fragments"](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment) or
 [`React.Fragment`](https://pt-br.reactjs.org/docs/react-api.html#reactfragment))
 are represented as arrays:
 
@@ -104,9 +104,8 @@ htm"<p><strong>This is $(orange(\"really\")) important.</strong></p>"
 ```
 
 You can even use
-[`@html_str`](https://docs.julialang.org/en/v1/base/strings/#Base.Docs.@html_str)
-(from `Base.Docs`)
-and [`@md_str`](https://docs.julialang.org/en/v1/stdlib/Markdown/)
+[`Base.Docs.@html_str`](https://docs.julialang.org/en/v1/base/strings/#Base.Docs.@html_str)
+and [`Markdown.@md_str`](https://docs.julialang.org/en/v1/stdlib/Markdown/)
 from the [standard library](https://docs.julialang.org/en/v1/):
 
 ```jldoctest
@@ -115,6 +114,10 @@ julia> using Markdown
 julia> htm"<div>$(md\"# 🍍\")</div>"
 <div><div class="markdown"><h1>🍍</h1>
 </div></div>
+
+julia> md"# $(htm\"<em>🍍</em>\")"
+  <em>🍍</em>
+  ≡≡≡≡≡≡≡≡≡≡≡≡
 ```
 
 ```jldoctest

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -50,7 +50,8 @@ true
 ```
 
 Multiple top-level elements
-(["document fragments"](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment))
+(["document fragments"](https://developer.mozilla.org/en-US/docs/Web/API/DocumentFragment),
+[`React.Fragment`](https://pt-br.reactjs.org/docs/react-api.html#reactfragment))
 are represented as arrays:
 
 ```jldoctest

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -109,9 +109,14 @@ and [`@md_str`](https://docs.julialang.org/en/v1/stdlib/Markdown/)
 from the [standard library](https://docs.julialang.org/en/v1/):
 
 ```jldoctest
-julia> htm"<div>$(md\"# 🍍\")</div>"
-<div><p class="markdown"><h1> 🍍</h1></p></div>
+julia> using Markdown
 
+julia> htm"<div>$(md\"# 🍍\")</div>"
+<div><div class="markdown"><h1>🍍</h1>
+</div></div>
+```
+
+```jldoctest
 julia> htm"<p>🍍$(html\"&nbsp;\")🍌</p>"
 <p>🍍&nbsp;🍌</p>
 ```

--- a/src/HTM.jl
+++ b/src/HTM.jl
@@ -178,7 +178,7 @@ julia> HTM.skipcomment(io)
 true
 
 julia> read(io, Char)
-'🍍'
+'🍍': Unicode U+1F34D (category So: Symbol, other)
 ```
 """
 @inline function skipcomment(io::IO)

--- a/src/HTM.jl
+++ b/src/HTM.jl
@@ -50,7 +50,8 @@ julia> create_element("div", Dict("class" => "fruit"), "🍍")
 @inline processattrs(d::AbstractDict) = Dict(processattrs.(filter(isenabled∘last, collect(d))))
 
 @inline processattrs(🍎, ::Val) = processattrs(🍎)
-@inline processattrs(d::AbstractDict, ::Val{:style}) = *((string(first(p), ':', last(p), ';') for p in processattrs(d))...)
+@inline processattrs(d::AbstractDict, ::Val{:style}) = *((string(first(p), ':', last(p), ';') for p in processattrs(d))...)  # TODO: should we process first/last and not dict?
+@inline processattrs(v::AbstractVector, ::Val{:class}) = *((string(processattrs(c), ' ') for c in Set(v))...)  # TODO: remove space at the end?
 
 # Hide attributes if `false` or `nothing`, Hyperscript.jl uses `nothing` to
 # mean something else (empty attribute).

--- a/src/HTM.jl
+++ b/src/HTM.jl
@@ -4,7 +4,7 @@ using Hyperscript
 
 export @htm_str
 
-const UNIVERSALENDTAG = "<//>"
+const UENDTAG = "<//>"
 
 include("utils.jl")
 
@@ -14,93 +14,101 @@ include("utils.jl")
 Create a Hyperscript.jl element.
 
 This is an alternative syntax and (currently) serves as a rather trivial
-absctraction layer inspired by
+abstraction layer inspired by
 [`React.createElement`](https://pt-br.reactjs.org/docs/react-api.html#createelement).
 
 ```jldoctest
-julia> HTM.create_element("div", Dict("class" => "fruit"), "🍍")
+julia> HTM.create_element("div", ["class" => "fruit"], "🍍")
 <div class="fruit">🍍</div>
 ```
 """
 @inline create_element(tag, attrs, children...) = Hyperscript.Node(Hyperscript.DEFAULT_HTMLSVG_CONTEXT, tag, children, attrs)
 
 """
-    render(x::MyType)
+    Node(tag[, attrs, children])
 
-Generic function that defines how a Julia object is rendered.
-
-This should normally return a `HTM.Node` object.
-
-This is an alternative to `show(io::IO, m::MIME"text/html", x)` inspired by
-WebIO and should only be redefined when Julia's display system is not
-powerful enough for your needs.
+Compile time internal representation of a node.
 
 ```jldoctest
-julia> struct MyPlot
-           s::Scope
-       end
-
-julia> HTM.render(p::MyPlot) = HTM.render(p.s)
-```
-"""
-@inline render(🍎) = 🍎
-@inline render(x::Expr) = :($(render)($(x)))  # TODO: retire definitions for Expr and call them in toexpr?
-@inline render(b::Bool) = nothing
-
-@inline processtag(🍎) = 🍎
-@inline processtag(x::Expr) = :($(processtag)($(x)))
-@inline processtag(v::AbstractVector) = string(processtag.(v)...)
-@inline processtag(v::AbstractVector{T}) where {T<:AbstractString} = *(processtag.(v)...)
-
-@inline processattrs(🍎) = 🍎
-# TODO: this merge is a pain. What I want:
-# - say goodbye to promises and use a single variable for attributes
-# - this variable should be able to hold pairs, dicts, etc. and create a dict
-# in order
-# - this will ensure we can support precedence (currently spread attributes
-# always take precedence, no matter where they are given.
-# - same philosophy as with tags and children: store objects as they are,
-# handle later.
-@inline processattrs(x::Expr, p::Expr) = (x = :(merge!($(x), $(p)...)); :($(processattrs)($(x))))  # promises update.
-@inline processattrs(b::Bool) = b ? nothing : error("should have been disabled")
-@inline processattrs(v::AbstractVector{T}) where {T<:AbstractString} = *(processattrs.(v)...)
-@inline processattrs(p::Pair) = (k = first(p); string(k) => processattrs(last(p), Val(Symbol(k))))  # no interps in keys: use spread attributes
-@inline processattrs(d::AbstractDict) = Dict(processattrs.(filter(isenabled∘last, collect(d))))
-
-@inline processattrs(🍎, ::Val) = processattrs(🍎)
-@inline processattrs(d::AbstractDict, ::Val{:style}) = *((string(first(p), ':', last(p), ';') for p in processattrs(d))...)  # TODO: should we process first/last and not dict? TODO: add space between key/value
-@inline processattrs(v::AbstractVector, ::Val{:class}) = *((string(processattrs(c), ' ') for c in Set(v))...)  # TODO: remove space at the end
-
-# Hide attributes if `false` or `nothing`, Hyperscript.jl uses `nothing` to
-# mean something else (empty attribute).
-@inline isenabled(🍎) = true
-@inline isenabled(::Nothing) = false
-@inline isenabled(b::Bool) = b
-
-"""
-    Node(tag, attrs, promises=String[], children=Union{String, HTM.Node}[])
-
-Compile time internal representation of an HTML node.
-
-```jldoctest
-julia> HTM.Node(["div"], Dict("class" => ["fruit"]), [], ["🍍"])
-HTM.Node(["div"], Dict("class" => ["fruit"]), String[], Union{String, HTM.Node}["🍍"])
+julia> HTM.Node(["div"], ["class" => ["fruit"]], ["🍍"])
+HTM.Node(["div"], ["class" => ["fruit"]], Union{String, HTM.Node}["🍍"])
 ```
 """
 struct Node
     tag::Vector{String}
-    attrs::Dict{String,Vector{String}}
-    promises::Vector{String}
-    children::Vector{Union{String, HTM.Node}}
-    Node(tag, attrs, promises=String[], children=Union{String, HTM.Node}[]) = new(tag, attrs, promises, children)
+    attrs::Vector{Pair{String,Vector{String}}}
+    children::Vector{Union{String,HTM.Node}}
+    Node(tag, attrs=Pair{String,Vector{String}}[], children=Union{String,HTM.Node}[]) = new(tag, attrs, children)
 end
-Base.:(==)(🍍::Node, 🍌::Node) = 🍍.tag == 🍌.tag && 🍍.attrs == 🍌.attrs && 🍍.promises == 🍌.promises && 🍍.children == 🍌.children
+Base.:(==)(🍍::Node, 🍌::Node) = 🍍.tag == 🍌.tag && 🍍.attrs == 🍌.attrs && 🍍.children == 🍌.children
 
-macro htm_str(s)
-    htm = parse(s)
-    esc(toexprmacro(htm))
+@doc raw"""
+    render(x::MyType)
+
+Generic function that defines how a Julia object is rendered.
+
+This should normally return using [`@htm_str`](@ref).
+
+This is an alternative to `Base.show(io::IO, m::MIME"text/html", x)` inspired
+by WebIO and should only be redefined when Julia's display system is not
+powerful enough for your needs.
+
+```jldoctest
+julia> struct Fruit
+           name::String
+           emoji::Char
+       end
+
+julia> HTM.render(🍎::Fruit) = htm"$(🍎.name): <div class=fruit>$(🍎.emoji)</div>"
+
+julia> htm"<p>$(Fruit(\\"pineapple\\", '🍍'))</p>"
+<p>pineapple: <div class="fruit">🍍</div></p>
+```
+"""
+@inline render(🍎) = 🍎
+@inline render(::Bool) = nothing
+
+@inline rendertag(🍎) = 🍎
+@inline rendertag(v::AbstractVector) = string(rendertag.(v)...)
+@inline rendertag(v::AbstractVector{T}) where {T<:AbstractString} = *(rendertag.(v)...)
+
+# TODO: simplify and benchmark things related to renderattrs
+@inline function renderattrs(v::AbstractVector)
+    attrs = Pair{String,Any}[]  # TODO: better type?
+    # TODO: use foreach for this and others
+    for p in v
+        isenabled(p) && pushattr!(attrs, renderattr(p))
+    end
+    return attrs
 end
+@inline renderattrs(d::AbstractDict) = renderattrs(collect(d))  # TODO: remove AbstractDict and use it as a fallback?
+@inline pushattr!(v::AbstractVector, p::Pair) = push!(v, p)
+@inline pushattr!(v::AbstractVector, p::AbstractVector) = append!(v, p)
 
+@inline renderattr(p::Pair) = renderattr(first(p), last(p))
+@inline renderattr(k, v) = renderattr(Val(Symbol(k)), v)  # TODO: use symbols all the way for keys, as we don't interpolate them anyway
+
+# TODO: support vector of pairs as well
+@inline renderattr(::Val{:style}, d::AbstractDict) = "style" => *((string(first(p), ':', last(p), ';') for p in d)...)  # TODO: should we process first/last and not dict? TODO: add space between key/value
+
+@inline renderattr(::Val{:class}, v::AbstractVector) = "class" => *((string(c, ' ') for c in Set(v))...)  # TODO: remove space at the end
+
+@inline renderattr(::Val{C}, x) where {C} = renderkey(C) => rendervalue(x)  # TODO: should we really use a separate function for keys?
+@inline renderattr(::Val{Symbol()}, d) = renderattrs(d)  # spread attributes
+
+@inline renderkey(🍎) = 🍎  # no interps in keys: use spread attributes  # TODO: probably useless if we only use symbols
+@inline renderkey(s::Symbol) = string(s)  # TODO: is it worth using attrs = Pair{Symbol,Any}[]? Benchmark
+@inline rendervalue(🍎) = 🍎
+
+@inline rendervalue(b::Bool) = b ? nothing : error("should have been disabled")  # TODO: can we pass this logic to isenabled? It feels too spread out
+@inline rendervalue(v::AbstractVector{T}) where {T<:AbstractString} = *(v...)
+
+@inline isenabled(🍎) = true
+@inline isenabled(b::Bool) = b
+@inline isenabled(::Nothing) = false
+@inline isenabled(p::Pair) = isenabled(last(p))
+
+# TODO: review all toexpr...
 @inline function toexprmacro(v::AbstractVector)
     length(v) > 1 && return toexpr(v)
     isempty(v) && return nothing
@@ -108,42 +116,51 @@ end
 end
 
 @inline function toexpr(🍍::Node)
-    # TODO: can tag be empty? See <https://pt-br.reactjs.org/docs/fragments.html#short-syntax> for a usage.
-    tag = isempty(🍍.tag) ? "" : processtag(toexprvec(🍍.tag))
-    attrs = (isempty(🍍.attrs) && isempty(🍍.promises)) ? Dict{String,Any}() : processattrs(toexpr(🍍.attrs), toexprvec(🍍.promises))
-    children = isempty(🍍.children) ? Any[] : render(toexpr(🍍.children))
+    tag = isempty(🍍.tag) ? "" : :($(rendertag)($(toexprvec(🍍.tag))))
+    attrs = isempty(🍍.attrs) ? Pair{String,Any}[] : :($(renderattrs)($(toexprvec(🍍.attrs))))
+    children = isempty(🍍.children) ? Any[] : :($(render)($(toexpr(🍍.children))))
     return :($(create_element)($(tag), $(attrs), $(children)))
 end
 @inline toexpr(s::AbstractString) = (length(s) > 1 && startswith(s, '$')) ? Meta.parse(s[nextind(s, begin):end]) : s
 @inline toexpr(v::AbstractVector) = length(v) == 1 ? :($(toexpr(first(v)))) : toexprvec(v)
 @inline toexpr(p::Pair) = (v = last(p); :($(first(p)) => $(length(v) > 1 ? toexpr(v) : toexpr(first(v)))))  # no interps in keys
-@inline toexpr(d::AbstractDict) = :(Dict($(toexpr(collect(d)))))
+@inline toexpr(d::AbstractVector{Pair}) = toexprvec(d)  # TODO: requires more specific type? Check this!
 
-@inline toexprvec(v::AbstractVector) = :([$(toexpr.(v)...)])
+@inline toexprvec(v::AbstractVector) = :([$(toexpr.(v)...)])  # TODO: should use reduce(vcat, v)?
+
+"""
+    @htm_str
+
+Create a DOM object from a literal string.
+
+Parsing is done via [`HTM.parse`](@ref).
+"""
+macro htm_str(s)
+    htm = parse(s)
+    esc(toexprmacro(htm))
+end
 
 @doc raw"""
     parse(s::AbstractString)
     parse(io::IO)
 
-Parse HTML.
+Parse a literal string.
 
 ```jldoctest
 julia> HTM.parse("pineapple: <div class=\\"fruit\\">🍍</div>...")
 3-element Vector{Union{String, HTM.Node}}:
  "pineapple: "
- HTM.Node(["div"], Dict("class" => ["fruit"]), String[], Union{String, HTM.Node}["🍍"])
+ HTM.Node(["div"], ["class" => ["fruit"]], Union{String, HTM.Node}["🍍"])
  "..."
 ```
 """
 @inline parse(io::IO) = parseelems(io)
 @inline parse(s::AbstractString) = parse(IOBuffer(s))
 
-# --- HTML specification ---
-
 @doc raw"""
     parseelems(io::IO)
 
-Parse HTML elements.
+Parse elements.
 
 This function is the entry point for an implementation of a subset of the
 [HTML standard](https://html.spec.whatwg.org/multipage/parsing.html#tokenization).
@@ -152,12 +169,12 @@ This function is the entry point for an implementation of a subset of the
 julia> HTM.parseelems(IOBuffer("pineapple: <div class=\\"fruit\\">🍍</div>..."))
 3-element Vector{Union{String, HTM.Node}}:
  "pineapple: "
- HTM.Node(["div"], Dict("class" => ["fruit"]), String[], Union{String, HTM.Node}["🍍"])
+ HTM.Node(["div"], ["class" => ["fruit"]], Union{String, HTM.Node}["🍍"])
  "..."
 ```
 """
 @inline parseelems(io::IO) = parseelems(io -> true, io)
-@inline parseelems(predicate, io::IO) = parseelems!(predicate, io, Union{String, HTM.Node}[])
+@inline parseelems(predicate, io::IO) = parseelems!(predicate, io, Union{String,HTM.Node}[])
 @inline function parseelems!(predicate, io::IO, elems::AbstractVector)
     while !eof(io) && predicate(io)
         skipcomment(io) || pushelem!(elems, parseelem(io))
@@ -170,7 +187,7 @@ end
 @doc raw"""
     parseelem(io::IO)
 
-Parse a single HTML element.
+Parse a single element.
 
 ```jldoctest
 julia> HTM.parseelem(IOBuffer("pineapple: <div class=\\"fruit\\">🍍</div>..."))
@@ -211,28 +228,28 @@ end
 @doc raw"""
     parsenode(io::IO)
 
-Parse a `Node` object.
+Parse an [`HTM.Node`](@ref) object.
 
 ```jldoctest
 julia> HTM.parsenode(IOBuffer("<div class=\\"fruit\\">🍍</div>..."))
-HTM.Node(["div"], Dict("class" => ["fruit"]), String[], Union{String, HTM.Node}["🍍"])
+HTM.Node(["div"], ["class" => ["fruit"]], Union{String, HTM.Node}["🍍"])
 ```
 """
 @inline function parsenode(io::IO)
     skipchars(isequal('<'), io)
     tag = parsetag(io)
-    attrs, promises = parseattrs(io)
-    read(io, Char) === '/' && (skipchars(isequal('>'), io); return Node(tag, attrs, promises))
-    endtag = string("</", processtag(tag), '>')
-    children = parseelems(io -> !(startswith(io, endtag) || startswith(io, UNIVERSALENDTAG)), io)
-    skipstartswith(io, endtag) || skipstartswith(io, UNIVERSALENDTAG) || error("tag not properly closed")
-    return Node(tag, attrs, promises, children)
+    attrs = parseattrs(io)
+    read(io, Char) === '/' && (skipchars(isequal('>'), io); return Node(tag, attrs))
+    endtag = string("</", rendertag(tag), '>')
+    children = parseelems(io -> !(startswith(io, endtag) || startswith(io, UENDTAG)), io)
+    skipstartswith(io, endtag) || skipstartswith(io, UENDTAG) || error("tag not properly closed")
+    return Node(tag, attrs, children)
 end
 
 @doc raw"""
     parsetag(io::IO)
 
-Parse an HTML tag.
+Parse a tag.
 
 ```jldoctest
 julia> HTM.parsetag(IOBuffer("div class=\\"fruit\\">🍍..."))
@@ -251,32 +268,35 @@ end
 @doc raw"""
     parseattrs(io::IO)
 
-Parse HTML attributes of a node.
-The returned tuple contains both true attributes and promisses.
+Parse attributes of a node.
 
 ```jldoctest
 julia> HTM.parseattrs(IOBuffer("class=\\"fruit\\">🍍..."))
-(Dict("class" => ["fruit"]), String[])
+1-element Vector{Pair{String, Vector{String}}}:
+ "class" => ["fruit"]
 
 julia> HTM.parseattrs(IOBuffer("class=\\"fruit\\" \$(attrs)>🍍..."))
-(Dict("class" => ["fruit"]), ["\$(attrs)"])
+2-element Vector{Pair{String, Vector{String}}}:
+ "class" => ["fruit"]
+ "" => ["\$(attrs)"]
 ```
 """
-@inline parseattrs(io::IO) = parseattrs!(io, Dict{String,Vector{String}}(), String[])
-@inline function parseattrs!(io::IO, attrs::AbstractDict, promises::AbstractVector)
+@inline parseattrs(io::IO) = parseattrs!(io, Pair{String,Vector{String}}[])
+@inline function parseattrs!(io::IO, attrs::AbstractVector)
     while !eof(io)
         skipchars(isspace, io)
         startswith(io, ('>', '/')) && break
-        startswith(io, '$') ? push!(promises, parseinterp(io)) : (attrs = parseattr!(io, attrs))
+        parseattr!(io, attrs)
     end
-    return attrs, promises
+    return attrs
 end
-@inline function parseattr!(io::IO, attrs::AbstractDict)
+@inline function parseattr!(io::IO, attrs::AbstractVector)
+    eof(io) && return push!(attrs, key => [raw"$(true)"])  # TODO: do we need this? test! this seems like defective input, just throw an error!
+    startswith(io, '$') && return push!(attrs, "" => [parseinterp(io)])  # spread attributes
     startswith(io, "\\\$") && skip(io, 1)  # no interps in keys: just ignore escaping
     key = parsekey(io)
-    eof(io) && (attrs[key] = [raw"$(true)"]; return attrs)
     let 🍒 = read(io, Char)
-        attrs[key] = 🍒 === '=' ? parsevalue(io) : [raw"$(true)"]
+        push!(attrs, key => 🍒 === '=' ? parsevalue(io) : [raw"$(true)"])
         🍒 ∈ ">/" && skip(io, -1)
     end
     return attrs
@@ -285,7 +305,7 @@ end
 @doc raw"""
     parsekey(io::IO)
 
-Parse an HTML attribute key.
+Parse an attribute key.
 
 ```jldoctest
 julia> HTM.parsekey(IOBuffer("class=\\"fruit\\">🍍..."))
@@ -297,7 +317,7 @@ julia> HTM.parsekey(IOBuffer("class=\\"fruit\\">🍍..."))
 @doc raw"""
     parsevalue(io::IO)
 
-Parse an HTML attribute value.
+Parse an attribute value.
 
 ```jldoctest
 julia> HTM.parsevalue(IOBuffer("\\"fruit\\">🍍..."))
@@ -329,7 +349,7 @@ end
 Parse an interpolation as string, including `$`.
 
 The input must start with `$` if no fallback function is given.
-The fallback function is passed to `readuntil` if the input does not start
+The fallback function is passed to `HTM.readuntil` if the input does not start
 with `$`.
 
 ```jldoctest

--- a/src/HTM.jl
+++ b/src/HTM.jl
@@ -123,7 +123,7 @@ end
 # expressions for generic contexts
 @inline toexpr(s::AbstractString) = (length(s) > 1 && startswith(s, '$')) ? Meta.parse(s[nextind(s, begin):end]) : s
 @inline toexpr(v::AbstractVector) = length(v) === 1 ? :($(toexpr(first(v)))) : vectoexpr(v)
-@inline toexpr(p::Pair) = (v = last(p); :($(:(first($(p)))) => $(length(v) > 1 ? toexpr(v) : toexpr(first(v)))))  # no interps in keys
+@inline toexpr(p::Pair) = (v = last(p); :($(:(first($(p)))) => $(valtoexpr(last(p)))))  # no interps in keys
 @inline toexpr(🍍::Node) = :($(create_element)($(tagtoexpr(🍍.tag)), $(attrstoexpr(🍍.attrs)), $(childrentoexpr(🍍.children))))
 
 # expressions for specific contexts
@@ -132,6 +132,7 @@ end
 @inline childrentoexpr(x) = isempty(x) ? Any[] : :($(render)($(toexpr(x))))
 
 @inline vectoexpr(v::AbstractVector) = :([$(toexpr.(v)...)])  # TODO: should use reduce(vcat, v)? benchmark
+@inline valtoexpr(v::AbstractVector) = length(v) > 1 ? toexpr(v) : (isempty(v) ? "" : toexpr(first(v)))
 @inline function macrotoexpr(v::AbstractVector)
     length(v) > 1 && return toexpr(v)
     isempty(v) && return nothing

--- a/src/HTM.jl
+++ b/src/HTM.jl
@@ -1,17 +1,17 @@
 module HTM
 
 using Hyperscript
-
 export @htm_str
 
 const UENDTAG = "<//>"
 
-include("utils.jl")
+include("util.jl")
+include("parse.jl")
 
 """
     create_element(tag, attrs[, children...])
 
-Create a Hyperscript.jl element.
+Create a DOM element.
 
 This is an alternative syntax and (currently) serves as a rather trivial
 abstraction layer inspired by
@@ -43,7 +43,7 @@ end
 Base.:(==)(🍍::Node, 🍌::Node) = 🍍.tag == 🍌.tag && 🍍.attrs == 🍌.attrs && 🍍.children == 🍌.children
 
 @doc raw"""
-    render(x::MyType)
+    render(x)
 
 Generic function that defines how a Julia object is rendered.
 
@@ -72,7 +72,6 @@ julia> htm"<p>$(Fruit(\\"pineapple\\", '🍍'))</p>"
 @inline create_tag(v::AbstractVector) = string(create_tag.(v)...)
 @inline create_tag(v::AbstractVector{S}) where {S<:AbstractString} = *(create_tag.(v)...)
 
-
 @inline create_value(🍎) = 🍎
 @inline create_value(b::Bool) = b ? nothing : error("should have been disabled")
 @inline create_value(v::AbstractVector{S}) where {S<:AbstractString} = *(v...)
@@ -81,22 +80,19 @@ julia> htm"<p>$(Fruit(\\"pineapple\\", '🍍'))</p>"
 @inline isenabled(b::Bool) = b
 @inline isenabled(::Nothing) = false
 
+# TODO: benchmark things related to create_attrs
+# TODO: is it worth using attrs = Pair{Symbol,Any}[]? Benchmark!
 
-# --- #
-# TODO: REVIEW create_attrs & friends
-# TODO: simplify and benchmark things related to create_attrs
 @inline create_attrs(d::AbstractDict) = create_attrs(collect(d))
 @inline create_attrs(v::AbstractVector) = (attrs = Pair{Symbol,Any}[]; foreach(p -> isenabled(last(p)) && pushattr!(attrs, create_attr(p)), v); attrs)  # TODO: choose type as we build the array?
-@inline pushattr!(v::AbstractVector, p::Pair) = push!(v, p)  # TODO: benchmark isenabled here and filter below instead of in create_attrs
 @inline pushattr!(v::AbstractVector, p::AbstractVector) = append!(v, p)
+@inline pushattr!(v::AbstractVector, p::Pair) = push!(v, p)  # TODO: benchmark isenabled here and filter below instead of in create_attrs
 
 @inline create_attr(p::Pair) = create_attr(first(p), last(p))
 @inline create_attr(🔑::Symbol, v) = create_attr(Val(🔑), v)
 @inline create_attr(🔑, v) = create_attr(Symbol(🔑), v)
-# --- #
 
-
-# TODO: is it worth using attrs = Pair{Symbol,Any}[]? Benchmark!
+# attribute fallback
 @inline create_attr(::Val{K}, x) where {K} = K => create_value(x)  # no interps in keys: use spread attributes
 
 # spread attributes
@@ -112,26 +108,6 @@ julia> htm"<p>$(Fruit(\\"pineapple\\", '🍍'))</p>"
 @inline create_attr(::Val{:class}, m::AbstractSet) = :class => *((*(c, ' ') for c in m)...)  # TODO: adjust spaces around classes?
 @inline create_attr(🔑::Val{:class}, v) = create_attr(🔑, Set(v))
 
-
-# TODO: REVIEW all toexpr...
-@inline function toexprmacro(v::AbstractVector)
-    length(v) > 1 && return toexpr(v)
-    isempty(v) && return nothing
-    return toexpr(first(v))
-end
-
-@inline function toexpr(🍍::Node)
-    tag = isempty(🍍.tag) ? "" : :($(create_tag)($(toexprvec(🍍.tag))))
-    attrs = isempty(🍍.attrs) ? Pair{Symbol,Any}[] : :($(create_attrs)($(toexprvec(🍍.attrs))))
-    children = isempty(🍍.children) ? Any[] : :($(render)($(toexpr(🍍.children))))
-    return :($(create_element)($(tag), $(attrs), $(children)))
-end
-@inline toexpr(s::AbstractString) = (length(s) > 1 && startswith(s, '$')) ? Meta.parse(s[nextind(s, begin):end]) : s
-@inline toexpr(v::AbstractVector) = length(v) == 1 ? :($(toexpr(first(v)))) : toexprvec(v)
-@inline toexpr(p::Pair) = (v = last(p); :($(:(first($(p)))) => $(length(v) > 1 ? toexpr(v) : toexpr(first(v)))))  # no interps in keys
-
-@inline toexprvec(v::AbstractVector) = :([$(toexpr.(v)...)])  # TODO: should use reduce(vcat, v)?
-
 """
     @htm_str
 
@@ -141,250 +117,25 @@ Parsing is done via [`HTM.parse`](@ref).
 """
 macro htm_str(s)
     htm = parse(s)
-    esc(toexprmacro(htm))
+    esc(macrotoexpr(htm))
 end
 
-@doc raw"""
-    parse(s::AbstractString)
-    parse(io::IO)
+# expressions for generic contexts
+@inline toexpr(s::AbstractString) = (length(s) > 1 && startswith(s, '$')) ? Meta.parse(s[nextind(s, begin):end]) : s
+@inline toexpr(v::AbstractVector) = length(v) === 1 ? :($(toexpr(first(v)))) : vectoexpr(v)
+@inline toexpr(p::Pair) = (v = last(p); :($(:(first($(p)))) => $(length(v) > 1 ? toexpr(v) : toexpr(first(v)))))  # no interps in keys
+@inline toexpr(🍍::Node) = :($(create_element)($(tagtoexpr(🍍.tag)), $(attrstoexpr(🍍.attrs)), $(childrentoexpr(🍍.children))))
 
-Parse a literal string.
+# expressions for specific contexts
+@inline tagtoexpr(x) = isempty(x) ? "" : :($(create_tag)($(toexpr(x))))
+@inline attrstoexpr(x) = isempty(x) ? Pair{Symbol,Any}[] : :($(create_attrs)($(vectoexpr(x))))
+@inline childrentoexpr(x) = isempty(x) ? Any[] : :($(render)($(toexpr(x))))
 
-```jldoctest
-julia> HTM.parse("pineapple: <div class=\\"fruit\\">🍍</div>...")
-3-element Vector{Union{String, HTM.Node}}:
- "pineapple: "
- HTM.Node(["div"], [:class => ["fruit"]], Union{String, HTM.Node}["🍍"])
- "..."
-```
-"""
-@inline parse(io::IO) = parseelems(io)
-@inline parse(s::AbstractString) = parse(IOBuffer(s))
-
-@doc raw"""
-    parseelems(io::IO)
-
-Parse elements.
-
-This function is the entry point for an implementation of a subset of the
-[HTML standard](https://html.spec.whatwg.org/multipage/parsing.html#tokenization).
-
-```jldoctest
-julia> HTM.parseelems(IOBuffer("pineapple: <div class=\\"fruit\\">🍍</div>..."))
-3-element Vector{Union{String, HTM.Node}}:
- "pineapple: "
- HTM.Node(["div"], [:class => ["fruit"]], Union{String, HTM.Node}["🍍"])
- "..."
-```
-"""
-@inline parseelems(io::IO) = parseelems(io -> true, io)
-@inline parseelems(predicate, io::IO) = parseelems!(predicate, io, Union{String,HTM.Node}[])
-@inline function parseelems!(predicate, io::IO, elems::AbstractVector)
-    while !eof(io) && predicate(io)
-        skipcomment(io) || pushelem!(elems, parseelem(io))
-    end
-    return elems
+@inline vectoexpr(v::AbstractVector) = :([$(toexpr.(v)...)])  # TODO: should use reduce(vcat, v)? benchmark
+@inline function macrotoexpr(v::AbstractVector)
+    length(v) > 1 && return toexpr(v)
+    isempty(v) && return nothing
+    return toexpr(first(v))
 end
-@inline pushelem!(elems::AbstractVector, elem) = push!(elems, elem)
-@inline pushelem!(elems::AbstractVector, elem::AbstractString) = (isempty(elem) || all(isspace, elem)) ? elems : push!(elems, elem)  # TODO: detect all spaces during reading for performance
-
-@doc raw"""
-    parseelem(io::IO)
-
-Parse a single element.
-
-```jldoctest
-julia> HTM.parseelem(IOBuffer("pineapple: <div class=\\"fruit\\">🍍</div>..."))
-"pineapple: "
-```
-"""
-@inline function parseelem(io::IO)
-    startswith(io, '<') && return parsenode(io)
-    skipstartswith(io, "\\\$") && return "\$"  # frustrated interp
-    return parseinterp(∈("<\$\\"), io)
-end
-
-@doc raw"""
-    skipcomment(io::IO)
-
-Skip a comment if any.
-
-```jldoctest
-julia> io = IOBuffer("<!-- 🍌 -->🍍");
-
-julia> HTM.skipcomment(io)
-true
-
-julia> read(io, Char)
-'🍍': Unicode U+1F34D (category So: Symbol, other)
-```
-"""
-@inline function skipcomment(io::IO)
-    if skipstartswith(io, "<!--")
-        while !(eof(io) || skipstartswith(io, "-->"))
-            skip(io, 1)
-        end
-        return true
-    end
-    return false
-end
-
-@doc raw"""
-    parsenode(io::IO)
-
-Parse an [`HTM.Node`](@ref) object.
-
-```jldoctest
-julia> HTM.parsenode(IOBuffer("<div class=\\"fruit\\">🍍</div>..."))
-HTM.Node(["div"], [:class => ["fruit"]], Union{String, HTM.Node}["🍍"])
-```
-"""
-@inline function parsenode(io::IO)
-    skipchars(isequal('<'), io)
-    tag = parsetag(io)
-    attrs = parseattrs(io)
-    read(io, Char) === '/' && (skipchars(isequal('>'), io); return Node(tag, attrs))
-    endtag = *("</", create_tag(tag), '>')
-    children = parseelems(io -> !(startswith(io, endtag) || startswith(io, UENDTAG)), io)
-    skipstartswith(io, endtag) || skipstartswith(io, UENDTAG) || error("tag not properly closed")
-    return Node(tag, attrs, children)
-end
-
-@doc raw"""
-    parsetag(io::IO)
-
-Parse a tag.
-
-```jldoctest
-julia> HTM.parsetag(IOBuffer("div class=\\"fruit\\">🍍..."))
-1-element Vector{String}:
- "div"
-```
-"""
-@inline function parsetag(io::IO)
-    🧩 = String[]
-    while !(eof(io) || (🍒 = peek(io, Char)) |> isspace || 🍒 ∈ ">/")
-        push!(🧩, skipstartswith(io, "\\\$") ? "\$" : parseinterp(isspace ⩔ ∈(">/\$\\"), io))
-    end
-    return 🧩
-end
-
-@doc raw"""
-    parseattrs(io::IO)
-
-Parse attributes of a node.
-
-```jldoctest
-julia> HTM.parseattrs(IOBuffer("class=\\"fruit\\">🍍..."))
-1-element Vector{Pair{Symbol, Vector{String}}}:
- :class => ["fruit"]
-
-julia> HTM.parseattrs(IOBuffer("class=\\"fruit\\" \$(attrs)>🍍..."))
-2-element Vector{Pair{Symbol, Vector{String}}}:
-   :class => ["fruit"]
- Symbol() => ["\$(attrs)"]
-```
-"""
-@inline parseattrs(io::IO) = parseattrs!(io, Pair{Symbol,Vector{String}}[])
-@inline function parseattrs!(io::IO, attrs::AbstractVector)
-    while !eof(io)
-        skipchars(isspace, io)
-        startswith(io, ('>', '/')) && break
-        parseattr!(io, attrs)
-    end
-    return attrs
-end
-@inline function parseattr!(io::IO, attrs::AbstractVector)
-    eof(io) && return push!(attrs, 🔑 => [raw"$(true)"])  # TODO: do we need this? test! this seems like defective input, just throw an error! key is not even defined here!
-    startswith(io, '$') && return push!(attrs, Symbol() => [parseinterp(io)])  # spread attributes
-    startswith(io, "\\\$") && skip(io, 1)  # no interps in keys: just ignore escaping
-    🔑 = parsekey(io)
-    let 🍒 = read(io, Char)
-        push!(attrs, 🔑 => 🍒 === '=' ? parsevalue(io) : [raw"$(true)"])
-        🍒 ∈ ">/" && skip(io, -1)
-    end
-    return attrs
-end
-
-@doc raw"""
-    parsekey(io::IO)
-
-Parse an attribute key.
-
-```jldoctest
-julia> HTM.parsekey(IOBuffer("class=\\"fruit\\">🍍..."))
-:class
-```
-"""
-@inline parsekey(io::IO) = Symbol(readuntil(isspace ⩔ ∈("=>/"), io))
-
-@doc raw"""
-    parsevalue(io::IO)
-
-Parse an attribute value.
-
-```jldoctest
-julia> HTM.parsevalue(IOBuffer("\\"fruit\\">🍍..."))
-1-element Vector{String}:
- "fruit"
-```
-"""
-@inline parsevalue(io::IO) = startswith(io, ('"', '\'')) ? parsequotedvalue(io) : parseunquotedvalue(io)
-@inline function parsequotedvalue(io::IO)
-    🥝 = read(io, Char)
-    🧩 = String[]
-    while !(eof(io) || startswith(io, 🥝))
-        push!(🧩, skipstartswith(io, "\\\$") ? "\$" : parseinterp(∈((🥝, '$', '\\')), io))
-    end
-    skipchars(isequal(🥝), io)
-    return 🧩
-end
-@inline function parseunquotedvalue(io::IO)
-    startswith(io, "http") && return [parseinterp(isspace ⩔ isequal('>'), io)]
-    let f = isspace ⩔ ∈(">/\$\\")
-        return skipstartswith(io, "\\\$") ? ["\$", readuntil(f, io)] : [parseinterp(f, io)]
-    end
-end
-
-@doc raw"""
-    parseinterp(io::IO)
-    parseinterp(fallback, io::IO)
-
-Parse an interpolation as string, including `$`.
-
-The input must start with `$` if no fallback function is given.
-The fallback function is passed to `HTM.readuntil` if the input does not start
-with `$`.
-
-```jldoctest
-julia> HTM.parseinterp(IOBuffer(raw"$((1, (2, 3)))..."))
-"\$((1, (2, 3)))"
-```
-"""
-@inline function parseinterp(io::IO)
-    buf = IOBuffer()
-    write(buf, read(io, Char))
-    (eof(io) || isspace(peek(io, Char))) && return "\$"  # frustrated interp
-    # TODO: should we call Meta.parse here and avoid this while? This would
-    # require returning Expr, which might be good for removing some duty from
-    # strings.
-    if startswith(io, '(')
-        n = 1
-        write(buf, read(io, Char))
-        while n > 0
-            🍒 = read(io, Char)
-            if 🍒 === '('
-                n += 1
-            elseif 🍒 === ')'
-                n -= 1
-            end
-            write(buf, 🍒)
-        end
-    else
-        write(buf, readuntil(isspace ⩔ ∈("<>/\"\'=\$\\"), io))
-    end
-    return String(take!(buf))
-end
-@inline parseinterp(fallback, io::IO) = startswith(io, '$') ? parseinterp(io) : readuntil(fallback, io)
 
 end

--- a/src/HTM.jl
+++ b/src/HTM.jl
@@ -33,6 +33,7 @@ julia> create_element("div", Dict("class" => "fruit"), "🍍")
 
 @inline processchildren(🍎) = 🍎
 @inline processchildren(x::Expr) = :(processchildren($(x)))
+@inline processchildren(b::Bool) = nothing
 
 @inline processattrs(🍎) = 🍎
 # TODO: this merge is a pain. What I want:

--- a/src/parse.jl
+++ b/src/parse.jl
@@ -1,0 +1,245 @@
+# --- Parsing ---
+
+@doc raw"""
+    parse(s::AbstractString)
+    parse(io::IO)
+
+Parse a literal string.
+
+```jldoctest
+julia> HTM.parse("pineapple: <div class=\\"fruit\\">🍍</div>...")
+3-element Vector{Union{String, HTM.Node}}:
+ "pineapple: "
+ HTM.Node(["div"], [:class => ["fruit"]], Union{String, HTM.Node}["🍍"])
+ "..."
+```
+"""
+@inline parse(io::IO) = parseelems(io)
+@inline parse(s::AbstractString) = parse(IOBuffer(s))
+
+@doc raw"""
+    parseelems(io::IO)
+
+Parse elements.
+
+This function is the entry point for an implementation of a subset of the
+[HTML standard](https://html.spec.whatwg.org/multipage/parsing.html#tokenization).
+
+```jldoctest
+julia> HTM.parseelems(IOBuffer("pineapple: <div class=\\"fruit\\">🍍</div>..."))
+3-element Vector{Union{String, HTM.Node}}:
+ "pineapple: "
+ HTM.Node(["div"], [:class => ["fruit"]], Union{String, HTM.Node}["🍍"])
+ "..."
+```
+"""
+@inline parseelems(io::IO) = parseelems(io -> true, io)
+@inline parseelems(predicate, io::IO) = parseelems!(predicate, io, Union{String,HTM.Node}[])
+@inline function parseelems!(predicate, io::IO, elems::AbstractVector)
+    while !eof(io) && predicate(io)
+        skipcomment(io) || pushelem!(elems, parseelem(io))
+    end
+    return elems
+end
+@inline pushelem!(elems::AbstractVector, elem) = push!(elems, elem)
+@inline pushelem!(elems::AbstractVector, elem::AbstractString) = (isempty(elem) || all(isspace, elem)) ? elems : push!(elems, elem)  # TODO: detect all spaces during reading for performance
+
+@doc raw"""
+    parseelem(io::IO)
+
+Parse a single element.
+
+```jldoctest
+julia> HTM.parseelem(IOBuffer("pineapple: <div class=\\"fruit\\">🍍</div>..."))
+"pineapple: "
+```
+"""
+@inline function parseelem(io::IO)
+    startswith(io, '<') && return parsenode(io)
+    skipstartswith(io, "\\\$") && return "\$"  # frustrated interp
+    return parseinterp(∈("<\$\\"), io)
+end
+
+@doc raw"""
+    skipcomment(io::IO)
+
+Skip a comment if any.
+
+```jldoctest
+julia> io = IOBuffer("<!-- 🍌 -->🍍");
+
+julia> HTM.skipcomment(io)
+true
+
+julia> read(io, Char)
+'🍍': Unicode U+1F34D (category So: Symbol, other)
+```
+"""
+@inline function skipcomment(io::IO)
+    if skipstartswith(io, "<!--")
+        while !(eof(io) || skipstartswith(io, "-->"))
+            skip(io, 1)
+        end
+        return true
+    end
+    return false
+end
+
+@doc raw"""
+    parsenode(io::IO)
+
+Parse an [`HTM.Node`](@ref) object.
+
+```jldoctest
+julia> HTM.parsenode(IOBuffer("<div class=\\"fruit\\">🍍</div>..."))
+HTM.Node(["div"], [:class => ["fruit"]], Union{String, HTM.Node}["🍍"])
+```
+"""
+@inline function parsenode(io::IO)
+    skipchars(isequal('<'), io)
+    tag = parsetag(io)
+    attrs = parseattrs(io)
+    read(io, Char) === '/' && (skipchars(isequal('>'), io); return Node(tag, attrs))
+    endtag = *("</", create_tag(tag), '>')
+    children = parseelems(io -> !(startswith(io, endtag) || startswith(io, UENDTAG)), io)
+    skipstartswith(io, endtag) || skipstartswith(io, UENDTAG) || error("tag not properly closed")
+    return Node(tag, attrs, children)
+end
+
+@doc raw"""
+    parsetag(io::IO)
+
+Parse a tag.
+
+```jldoctest
+julia> HTM.parsetag(IOBuffer("div class=\\"fruit\\">🍍..."))
+1-element Vector{String}:
+ "div"
+```
+"""
+@inline function parsetag(io::IO)
+    🧩 = String[]
+    while !(eof(io) || (🍒 = peek(io, Char)) |> isspace || 🍒 ∈ ">/")
+        push!(🧩, skipstartswith(io, "\\\$") ? "\$" : parseinterp(isspace ⩔ ∈(">/\$\\"), io))
+    end
+    return 🧩
+end
+
+@doc raw"""
+    parseattrs(io::IO)
+
+Parse attributes of a node.
+
+```jldoctest
+julia> HTM.parseattrs(IOBuffer("class=\\"fruit\\">🍍..."))
+1-element Vector{Pair{Symbol, Vector{String}}}:
+ :class => ["fruit"]
+
+julia> HTM.parseattrs(IOBuffer("class=\\"fruit\\" \$(attrs)>🍍..."))
+2-element Vector{Pair{Symbol, Vector{String}}}:
+     :class => ["fruit"]
+ Symbol("") => ["\$(attrs)"]
+```
+"""
+@inline parseattrs(io::IO) = parseattrs!(io, Pair{Symbol,Vector{String}}[])
+@inline function parseattrs!(io::IO, attrs::AbstractVector)
+    while !eof(io)
+        skipchars(isspace, io)
+        startswith(io, ('>', '/')) && break
+        parseattr!(io, attrs)
+    end
+    return attrs
+end
+@inline function parseattr!(io::IO, attrs::AbstractVector)
+    startswith(io, '$') && return push!(attrs, Symbol() => [parseinterp(io)])  # spread attributes
+    startswith(io, "\\\$") && skip(io, 1)  # no interps in keys: just ignore escaping
+    🔑 = parsekey(io)
+    let 🍒 = read(io, Char)
+        push!(attrs, 🔑 => 🍒 === '=' ? parsevalue(io) : [raw"$(true)"])
+        🍒 ∈ ">/" && skip(io, -1)
+    end
+    return attrs
+end
+
+@doc raw"""
+    parsekey(io::IO)
+
+Parse an attribute key.
+
+```jldoctest
+julia> HTM.parsekey(IOBuffer("class=\\"fruit\\">🍍..."))
+:class
+```
+"""
+@inline parsekey(io::IO) = Symbol(readuntil(isspace ⩔ ∈("=>/"), io))
+
+@doc raw"""
+    parsevalue(io::IO)
+
+Parse an attribute value.
+
+```jldoctest
+julia> HTM.parsevalue(IOBuffer("\\"fruit\\">🍍..."))
+1-element Vector{String}:
+ "fruit"
+```
+"""
+@inline parsevalue(io::IO) = startswith(io, ('"', '\'')) ? parsequotedvalue(io) : parseunquotedvalue(io)
+@inline function parsequotedvalue(io::IO)
+    🥝 = read(io, Char)
+    🧩 = String[]
+    while !(eof(io) || startswith(io, 🥝))
+        push!(🧩, skipstartswith(io, "\\\$") ? "\$" : parseinterp(∈((🥝, '$', '\\')), io))
+    end
+    skipchars(isequal(🥝), io)
+    return 🧩
+end
+@inline function parseunquotedvalue(io::IO)
+    startswith(io, "http") && return [parseinterp(isspace ⩔ isequal('>'), io)]
+    let f = isspace ⩔ ∈(">/\$\\")
+        return skipstartswith(io, "\\\$") ? ["\$", readuntil(f, io)] : [parseinterp(f, io)]
+    end
+end
+
+@doc raw"""
+    parseinterp(io::IO)
+    parseinterp(fallback, io::IO)
+
+Parse an interpolation as string, including `$`.
+
+The input must start with `$` if no fallback function is given.
+The fallback function is passed to `HTM.readuntil` if the input does not start
+with `$`.
+
+```jldoctest
+julia> HTM.parseinterp(IOBuffer(raw"$((1, (2, 3)))..."))
+"\$((1, (2, 3)))"
+```
+"""
+@inline function parseinterp(io::IO)
+    buf = IOBuffer()
+    write(buf, read(io, Char))
+    (eof(io) || isspace(peek(io, Char))) && return "\$"  # frustrated interp
+    # TODO: call Meta.parse here and avoid this while. This will require
+    # returning Expr, which will remove some duty from strings. This can lead
+    # to better decisions when calling create_element by being able to
+    # distinguish between strings and expressions, which is currently
+    # impossible.
+    if startswith(io, '(')
+        n = 1
+        write(buf, read(io, Char))
+        while n > 0
+            🍒 = read(io, Char)
+            if 🍒 === '('
+                n += 1
+            elseif 🍒 === ')'
+                n -= 1
+            end
+            write(buf, 🍒)
+        end
+    else
+        write(buf, readuntil(isspace ⩔ ∈("<>/\"\'=\$\\"), io))
+    end
+    return String(take!(buf))
+end
+@inline parseinterp(fallback, io::IO) = startswith(io, '$') ? parseinterp(io) : readuntil(fallback, io)

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,7 +1,7 @@
-@inline ⩔(f, g) = x -> f(x) | g(x)
-
 # --- Utilities ---
 # That could be contributed to Julia.
+
+@inline ⩔(f, g) = x -> f(x) | g(x)
 
 """
     readuntil(predicate, io::IO)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,16 +192,16 @@ const r = Hyperscript.render
             @testset "As tags" begin
                 @testset "Matching end-tag" begin
                     @testset "Complete tags" begin
-                        @test htm"<$(nothing)></$(nothing)>" |> r == "<nothing></nothing>"
-                        @test htm"<$(missing)></$(missing)>" |> r == "<missing></missing>"
-                        @test htm"<$(1)></$(1)>" |> r == "<1></1>"
-                        @test htm"<$(1.0)></$(1.0)>" |> r == "<1.0></1.0>"
-                        @test htm"<$(true)></$(true)>" |> r == "<true></true>"
-                        @test htm"<$(:symbol)></$(:symbol)>" |> r == "<symbol></symbol>"
+                        @test_throws MethodError htm"<$(nothing)></$(nothing)>" |> r == "<nothing></nothing>"
+                        @test_throws MethodError htm"<$(missing)></$(missing)>" |> r == "<missing></missing>"
+                        @test_throws MethodError htm"<$(1)></$(1)>" |> r == "<1></1>"
+                        @test_throws MethodError htm"<$(1.0)></$(1.0)>" |> r == "<1.0></1.0>"
+                        @test_throws MethodError htm"<$(true)></$(true)>" |> r == "<true></true>"
+                        @test_throws MethodError htm"<$(:symbol)></$(:symbol)>" |> r == "<symbol></symbol>"
                         @test htm"<$(\"string\")></$(\"string\")>" |> r == "<string></string>"
                         @test htm"<$([1, 2, 3])></$([1, 2, 3])>" |> r == "<123></123>"
-                        @test htm"<$(\"class\" => \"fruit\")></$(\"class\" => \"fruit\")>" |> r == "<&#34;class&#34; &#61;&#62; &#34;fruit&#34;></&#34;class&#34; &#61;&#62; &#34;fruit&#34;>"
-                        @test htm"<$(Dict(\"class\" => \"fruit\"))></$(Dict(\"class\" => \"fruit\"))>" |> r == "<Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;></Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;>"
+                        @test_throws MethodError htm"<$(\"class\" => \"fruit\")></$(\"class\" => \"fruit\")>" |> r == "<&#34;class&#34; &#61;&#62; &#34;fruit&#34;></&#34;class&#34; &#61;&#62; &#34;fruit&#34;>"
+                        @test_throws MethodError htm"<$(Dict(\"class\" => \"fruit\"))></$(Dict(\"class\" => \"fruit\"))>" |> r == "<Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;></Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;>"
                     end
 
                     @testset "Partial tags" begin
@@ -220,16 +220,16 @@ const r = Hyperscript.render
 
                 @testset "Universal end-tag" begin
                     @testset "Complete tags" begin
-                        @test htm"<$(nothing)><//>" |> r == "<nothing></nothing>"
-                        @test htm"<$(missing)><//>" |> r == "<missing></missing>"
-                        @test htm"<$(1)><//>" |> r == "<1></1>"
-                        @test htm"<$(1.0)><//>" |> r == "<1.0></1.0>"
-                        @test htm"<$(true)><//>" |> r == "<true></true>"
-                        @test htm"<$(:symbol)><//>" |> r == "<symbol></symbol>"
+                        @test_throws MethodError htm"<$(nothing)><//>" |> r == "<nothing></nothing>"
+                        @test_throws MethodError htm"<$(missing)><//>" |> r == "<missing></missing>"
+                        @test_throws MethodError htm"<$(1)><//>" |> r == "<1></1>"
+                        @test_throws MethodError htm"<$(1.0)><//>" |> r == "<1.0></1.0>"
+                        @test_throws MethodError htm"<$(true)><//>" |> r == "<true></true>"
+                        @test_throws MethodError htm"<$(:symbol)><//>" |> r == "<symbol></symbol>"
                         @test htm"<$(\"string\")><//>" |> r == "<string></string>"
                         @test htm"<$([1, 2, 3])><//>" |> r == "<123></123>"
-                        @test htm"<$(\"class\" => \"fruit\")><//>" |> r == "<&#34;class&#34; &#61;&#62; &#34;fruit&#34;></&#34;class&#34; &#61;&#62; &#34;fruit&#34;>"
-                        @test htm"<$(Dict(\"class\" => \"fruit\"))><//>" |> r == "<Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;></Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;>"
+                        @test_throws MethodError htm"<$(\"class\" => \"fruit\")><//>" |> r == "<&#34;class&#34; &#61;&#62; &#34;fruit&#34;></&#34;class&#34; &#61;&#62; &#34;fruit&#34;>"
+                        @test_throws MethodError htm"<$(Dict(\"class\" => \"fruit\"))><//>" |> r == "<Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;></Dict&#40;&#34;class&#34; &#61;&#62; &#34;fruit&#34;&#41;>"
                     end
 
                     @testset "Partial tags" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ using HTM
 const r = Hyperscript.render
 
 @testset "HTM.jl" begin
+    # Warning: some test cases may not represent supported usage.
     @testset "Features" begin
         @testset "Spread attributes" begin
             attrs = Dict("class" => "fruit")
@@ -96,9 +97,8 @@ const r = Hyperscript.render
             end
 
             @testset "As attributes" begin
-                @testset "As keys" begin
-                    key = "class"
-                    @test_throws MethodError htm"<div $(key)=fruit></div>" |> r == "<div class=\"fruit\"></div>"
+                @testset "As keys" for key in ("class", :class, nothing, true, missing, 1, 1.0, [1, 2, 3], (1, 2, 3), "fruit" => "pineapple")
+                    @test_throws MethodError htm"<div $(key)=fruit></div>"
                 end
 
                 @testset "As values" begin
@@ -132,7 +132,6 @@ const r = Hyperscript.render
         end
 
         @testset "Literals" begin
-            # TODO: some of the test cases do not represent supported usage
             @testset "As children" begin
                 @test htm"<div>$(nothing)</div>" |> r == "<div></div>"
                 @test htm"<div>$(missing)</div>" |> r == "<div>missing</div>"
@@ -154,17 +153,6 @@ const r = Hyperscript.render
 
             @testset "As attributes" begin
                 @testset "As keys" begin
-                    # TODO: use for loops for checking MethodError with different types
-                    @test_throws MethodError htm"<div $(nothing)=fruit></div>" |> r == "<div nothing=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $(missing)=fruit></div>" |> r == "<div missing=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $(1)=fruit></div>" |> r == "<div 1=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $(1.0)=fruit></div>" |> r == "<div 1.0=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $(true)=fruit></div>" |> r == "<div true></div>"
-                    @test_throws MethodError htm"<div $(:symbol)=fruit></div>" |> r == "<div symbol=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $(\"string\")=fruit></div>" |> r == "<div string=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $([1, 2, 3])=fruit></div>" |> r == "<div 123=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $((1, 2, 3))=fruit></div>" |> r == "<div 123=\"fruit\"></div>"
-                    @test_throws MethodError htm"<div $(\"fruit\" => \"pineapple\")=fruit></div>" |> r == "<div &#34;fruit&#34; =&#62; &#34;pineapple&#34;=\"fruit\"></div>"
                     @test htm"<div $(Dict(\"fruit\" => \"pineapple\"))=fruit></div>" |> r == "<div fruit=\"pineapple\" =\"fruit\"></div>"
                 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,13 @@ const r = Hyperscript.render
             @test htm"<div /><div />" == [htm"<div />", htm"<div />"]
         end
 
+        @testset "Short circuit rendering" begin
+            @test htm"<div>$(true || \"🍍\")</div>" |> r == "<div></div>"
+            @test htm"<div>$(false || \"🍍\")</div>" |> r == "<div>🍍</div>"
+            @test htm"$(true || \"🍍\")" === true
+            @test htm"$(false || \"🍍\")" == "🍍"
+        end
+
         @testset "Boolean attributes" begin
             @test htm"<div draggable />" |> r == "<div draggable></div>"
             @test htm"<div draggable=$(true) />" |> r == "<div draggable></div>"
@@ -137,7 +144,7 @@ const r = Hyperscript.render
                 @test htm"<div>$(missing)</div>" |> r == "<div>missing</div>"
                 @test htm"<div>$(1)</div>" |> r == "<div>1</div>"
                 @test htm"<div>$(1.0)</div>" |> r == "<div>1.0</div>"
-                @test htm"<div>$(true)</div>" |> r == "<div>true</div>"
+                @test htm"<div>$(true)</div>" |> r == "<div></div>"
                 @test htm"<div>$(:symbol)</div>" |> r == "<div>symbol</div>"
                 @test htm"<div>$(\"string\")</div>" |> r == "<div>string</div>"
                 @test htm"<div>$([1, 2, 3])</div>" |> r == "<div>123</div>"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,46 @@ const r = Hyperscript.render
         # TODO: can tag be empty? See <https://pt-br.reactjs.org/docs/fragments.html#short-syntax> for a usage.
     end
 
+    @testset "Common HTML elements" begin
+        # The Pareto slice (>80%) of <https://www.advancedwebranking.com/html/>
+        @test htm"<html/>" |> r == "<html></html>"
+        @test htm"<head/>" |> r == "<head></head>"
+        @test htm"<body/>" |> r == "<body></body>"
+        @test htm"<title/>" |> r == "<title></title>"
+        @test htm"<meta/>" |> r == "<meta />"
+        @test htm"<div/>" |> r == "<div></div>"
+        @test htm"<a/>" |> r == "<a></a>"
+        @test htm"<link/>" |> r == "<link />"
+        @test htm"<span/>" |> r == "<span></span>"
+        @test htm"<p/>" |> r == "<p></p>"
+        @test htm"<li/>" |> r == "<li></li>"
+        @test htm"<ul/>" |> r == "<ul></ul>"
+        @test htm"<style/>" |> r == "<style></style>"
+
+        # Surprisingly common specifics
+        @test_broken htm"""<script>
+            document.getElementById("demo").innerHTML = "Hello JavaScript!";
+        </script>""" |> r == """<script>
+            document.getElementById("demo").innerHTML = "Hello JavaScript!";
+        </script>"""
+        @test htm"<img src=img_girl.jpg alt='Girl in a jacket' width=500 height=600/>" |> r == """<img alt="Girl in a jacket" height="600" src="img_girl.jpg" width="500" />"""
+        @test htm"<img src=red-circle.svg height=32 width=32 alt='A red circle'/>" |> r == """<img height="32" alt="A red circle" src="red-circle.svg" width="32" />"""
+        @test htm"<p>My favorite color is <del>blue</del> <ins>red</ins>!</p>" |> r == "<p>My favorite color is <del>blue</del><ins>red</ins>&#33;</p>"
+
+        @test htm"<source src=horse.ogg type='audio/ogg'/>" |> r == """<source src="horse.ogg" type="audio/ogg" />"""
+        @test htm"<template>
+            <h2>Flower</h2>
+            <img src=img_white_flower.jpg width=214 height=204/>
+        </template>" |> r == """<template><h2>Flower</h2><img height="204" src="img_white_flower.jpg" width="214" /></template>"""
+    end
+
+    @testset "Common SVG elements" begin
+        # TODO: make this more complete
+        @test htm"""<svg width=100 height=100>
+            <circle cx=50 cy=50 r=40 stroke=green stroke-width=4 fill=yellow/>
+        </svg>""" |> r == """<svg height="100" width="100"><circle cy="50" stroke-width="4" stroke="green" r="40" fill="yellow" cx="50" /></svg>"""
+    end
+
     @testset "Return types" begin
         @test htm"<div>🍍</div>" isa Hyperscript.Node
         @test htm"🍍" isa String

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,8 +64,8 @@ const r = Hyperscript.render
         end
 
         @testset "Classes" begin
-            @test_broken htm"<div class=$([1, 2, 3, 3])></div>" |> r == "<div class=\"1 2 3\"></div>"
-            @test_broken htm"<div class=$((1, 2, 3, 3))></div>" |> r == "<div class=\"1 2 3\"></div>"
+            # TODO: support iterables in general!
+            @test htm"<div class=$([\"fruit\", \"sour\", \"sour\"])></div>" |> r == "<div class=\"fruit sour \"></div>"
         end
 
         @testset "Callbacks" begin
@@ -243,16 +243,16 @@ const r = Hyperscript.render
             @test htm"<div \$(notvar) />" |> r == raw"""<div &#36;&#40;notvar&#41;></div>"""
 
             @test htm"<div \$notvar=fruit />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
-            @test htm"<div class=\$notvar />" |> r == raw"""<div class="$notvar"></div>"""
+            @test_broken htm"<div class=\$notvar />" |> r == raw"""<div class="$notvar"></div>"""
 
             @test htm"<div \$(notvar)=fruit />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
-            @test htm"<div class=\$(notvar) />" |> r == raw"""<div class="$(notvar)"></div>"""
+            @test_broken htm"<div class=\$(notvar) />" |> r == raw"""<div class="$(notvar)"></div>"""
 
             @test htm"<div \$notvar=\"fruit\" />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
-            @test htm"<div class=\"\$notvar\" />" |> r == raw"""<div class="$notvar"></div>"""
+            @test_broken htm"<div class=\"\$notvar\" />" |> r == raw"""<div class="$notvar"></div>"""
 
             @test htm"<div \$(notvar)=\"fruit\" />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
-            @test htm"<div class=\"\$(notvar)\" />" |> r == raw"""<div class="$(notvar)"></div>"""
+            @test_broken htm"<div class=\"\$(notvar)\" />" |> r == raw"""<div class="$(notvar)"></div>"""
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -108,6 +108,10 @@ const r = Hyperscript.render
         """ |> r == "<div class=\"fruit\">\n        🍍\n    </div>"
     end
 
+    @testset "Edge cases" begin
+        @test htm"<html class=no-js lang=\"\" />" |> r == "<html class=\"no-js\" lang=\"\"></html>"
+    end
+
     @testset "Interpolations" begin
         @testset "Variables" begin
             @testset "As children" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -71,6 +71,7 @@ const r = Hyperscript.render
         @testset "Styles" begin
             style = Dict("background" => "orange")
             @test htm"<span style=$(style)>pineapple</span>" |> r == "<span style=\"background:orange;\">pineapple</span>"
+            @test htm"<span style='background:$(style[\"background\"]);'>pineapple</span>" |> r == "<span style=\"background:orange;\">pineapple</span>"
         end
 
         @testset "Classes" begin
@@ -259,11 +260,11 @@ const r = Hyperscript.render
             @test htm"<div \$(notvar)=fruit />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
             @test_broken htm"<div class=\$(notvar) />" |> r == raw"""<div class="$(notvar)"></div>"""
 
-            @test htm"<div \$notvar=\"fruit\" />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
-            @test_broken htm"<div class=\"\$notvar\" />" |> r == raw"""<div class="$notvar"></div>"""
+            @test htm"<div \$notvar='fruit' />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
+            @test_broken htm"<div class='\$notvar' />" |> r == raw"""<div class="$notvar"></div>"""
 
-            @test htm"<div \$(notvar)=\"fruit\" />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
-            @test_broken htm"<div class=\"\$(notvar)\" />" |> r == raw"""<div class="$(notvar)"></div>"""
+            @test htm"<div \$(notvar)='fruit' />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
+            @test_broken htm"<div class='\$(notvar)' />" |> r == raw"""<div class="$(notvar)"></div>"""
         end
 
         @testset "HTML entity escape trick" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ const r = Hyperscript.render
             @test htm"<div draggable=$(false) />" |> r == "<div></div>"
         end
 
-        @testset "HTML's optional quotes" begin
+        @testset "HTML optional quotes" begin
             @test htm"<div class=fruit></div>" |> r == "<div class=\"fruit\"></div>"
 
             @testset "URLs" begin
@@ -146,8 +146,9 @@ const r = Hyperscript.render
                 @test htm"<div>$(Dict(\"fruit\" => \"pineapple\"))</div>" |> r == "<div>Dict&#40;&#34;fruit&#34; &#61;&#62; &#34;pineapple&#34;&#41;</div>"
 
                 @testset "Exotic objects" begin
-                    @test htm"<div>$(HTML(\"<div></div>\"))</div>" |> r == "<div><div></div></div>"
                     @test htm"<div>$(md\"# 🍍\")</div>" |> r == "<div><div class=\"markdown\"><h1>🍍</h1>\n</div></div>"
+                    @test htm"<div>$(html\"<div></div>\")</div>" |> r == "<div><div></div></div>"
+                    @test htm"<div>$(HTML(\"<div></div>\"))</div>" |> r == "<div><div></div></div>"
                 end
             end
 
@@ -253,6 +254,13 @@ const r = Hyperscript.render
 
             @test htm"<div \$(notvar)=\"fruit\" />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
             @test_broken htm"<div class=\"\$(notvar)\" />" |> r == raw"""<div class="$(notvar)"></div>"""
+        end
+
+        @testset "HTML entity escape trick" begin
+            @test htm"<p>🍍 🍌</p>" |> r == "<p>🍍 🍌</p>"
+            @test htm"<p>🍍&nbsp;🍌</p>" |> r == "<p>🍍&#38;nbsp;🍌</p>"
+            @test htm"<p>🍍$(html\"&nbsp;\")🍌</p>" |> r == "<p>🍍&nbsp;🍌</p>"
+            @test htm"<p>🍍$(HTML(\"&nbsp;\"))🍌</p>" |> r == "<p>🍍&nbsp;🍌</p>"
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,12 +10,14 @@ const r = Hyperscript.render
 @testset "HTM.jl" begin
     # Warning: some test cases may not represent supported usage.
     @testset "Features" begin
-        @testset "Spread attributes" for attrs in (["class" => "fruit"], Dict("class" => "fruit"))
+        @testset "Spread attributes" for attrs in ([:class => "fruit"], Dict(:class => "fruit"),
+                                                   ["class" => "fruit"], Dict("class" => "fruit"))
             @test htm"<div $(attrs)></div>" |> r == "<div class=\"fruit\"></div>"
         end
 
         @testset "Styles" begin
-            @testset "Interpolations" for style in (["background" => "orange"], Dict("background" => "orange"))
+            @testset "Interpolations" for style in ([:background => "orange"], Dict(:background => "orange"),
+                                                    ["background" => "orange"], Dict("background" => "orange"))
                 @test htm"<span style=$(style)>pineapple</span>" |> r == "<span style=\"background:orange;\">pineapple</span>"
             end
             @test htm"<span style='background:$(\"orange\");'>pineapple</span>" |> r == "<span style=\"background:orange;\">pineapple</span>"
@@ -255,21 +257,21 @@ const r = Hyperscript.render
             @test htm"<div>\$(notvar)</div>" |> r == raw"<div>&#36;&#40;notvar&#41;</div>"
 
             @test htm"<\$notvar />" |> r == raw"<&#36;notvar></&#36;notvar>"
-            @test htm"<div \$notvar />" |> r == raw"""<div &#36;notvar></div>"""
+            @test_broken htm"<div \$notvar />" |> r == raw"""<div &#36;notvar></div>"""
 
             @test htm"<\$(notvar) />" |> r == raw"<&#36;&#40;notvar&#41;></&#36;&#40;notvar&#41;>"
-            @test htm"<div \$(notvar) />" |> r == raw"""<div &#36;&#40;notvar&#41;></div>"""
+            @test_broken htm"<div \$(notvar) />" |> r == raw"""<div &#36;&#40;notvar&#41;></div>"""
 
-            @test htm"<div \$notvar=fruit />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
+            @test_broken htm"<div \$notvar=fruit />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
             @test_broken htm"<div class=\$notvar />" |> r == raw"""<div class="$notvar"></div>"""
 
-            @test htm"<div \$(notvar)=fruit />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
+            @test_broken htm"<div \$(notvar)=fruit />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
             @test_broken htm"<div class=\$(notvar) />" |> r == raw"""<div class="$(notvar)"></div>"""
 
-            @test htm"<div \$notvar='fruit' />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
+            @test_broken htm"<div \$notvar='fruit' />" |> r == raw"""<div &#36;notvar="fruit"></div>"""
             @test_broken htm"<div class='\$notvar' />" |> r == raw"""<div class="$notvar"></div>"""
 
-            @test htm"<div \$(notvar)='fruit' />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
+            @test_broken htm"<div \$(notvar)='fruit' />" |> r == raw"""<div &#36;&#40;notvar&#41;="fruit"></div>"""
             @test_broken htm"<div class='\$(notvar)' />" |> r == raw"""<div class="$(notvar)"></div>"""
         end
 
@@ -299,14 +301,14 @@ const r = Hyperscript.render
     @testset "Internal representation" begin
         @test HTM.parsenode(IOBuffer("<div />")) == HTM.Node(["div"])
         @test HTM.parsenode(IOBuffer("<div>Hi!</div>")) == HTM.Node(["div"], [], ["Hi!"])
-        @test HTM.parsenode(IOBuffer("<div class=fruit />")) == HTM.Node(["div"], ["class" => ["fruit"]])
-        @test HTM.parsenode(IOBuffer("<div class=fruit>Hi!</div>")) == HTM.Node(["div"], ["class" => ["fruit"]], ["Hi!"])
-        @test HTM.parsenode(IOBuffer("<div class=fruit>Hi there!</div>")) == HTM.Node(["div"], ["class" => ["fruit"]], ["Hi there!"])
+        @test HTM.parsenode(IOBuffer("<div class=fruit />")) == HTM.Node(["div"], [:class => ["fruit"]])
+        @test HTM.parsenode(IOBuffer("<div class=fruit>Hi!</div>")) == HTM.Node(["div"], [:class => ["fruit"]], ["Hi!"])
+        @test HTM.parsenode(IOBuffer("<div class=fruit>Hi there!</div>")) == HTM.Node(["div"], [:class => ["fruit"]], ["Hi there!"])
 
-        @test HTM.parsenode(IOBuffer("<button class=fruit disabled />")) == HTM.Node(["button"], ["class" => ["fruit"], "disabled" => [raw"$(true)"]])
-        @test HTM.parsenode(IOBuffer("<button class=fruit disabled>Click me</button>")) == HTM.Node(["button"], ["class" => ["fruit"], "disabled" => [raw"$(true)"]], ["Click me"])
+        @test HTM.parsenode(IOBuffer("<button class=fruit disabled />")) == HTM.Node(["button"], [:class => ["fruit"], :disabled => [raw"$(true)"]])
+        @test HTM.parsenode(IOBuffer("<button class=fruit disabled>Click me</button>")) == HTM.Node(["button"], [:class => ["fruit"], :disabled => [raw"$(true)"]], ["Click me"])
 
-        @test HTM.parsenode(IOBuffer("<circle fill=orange />")) == HTM.Node(["circle"], ["fill" => ["orange"]])
+        @test HTM.parsenode(IOBuffer("<circle fill=orange />")) == HTM.Node(["circle"], [:fill => ["orange"]])
 
         @testset "Stress tests" begin
             quotes = ("", '"', '\'')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -275,17 +275,17 @@ const r = Hyperscript.render
         end
     end
 
-    @testset "create_element" begin
-        @test create_element("div", (), ()) |> r == "<div></div>"
-        @test create_element("div", (), "Hi!") |> r == "<div>Hi&#33;</div>"
-        @test create_element("div", Dict("class" => "fruit")) |> r == "<div class=\"fruit\"></div>"
-        @test create_element("div", Dict("class" => "fruit"), "Hi!") |> r == "<div class=\"fruit\">Hi&#33;</div>"
-        @test create_element("div", Dict("class" => "fruit"), "Hi ", "there!") |> r == "<div class=\"fruit\">Hi there&#33;</div>"
+    @testset "Create elements" begin
+        @test HTM.create_element("div", (), ()) |> r == "<div></div>"
+        @test HTM.create_element("div", (), "Hi!") |> r == "<div>Hi&#33;</div>"
+        @test HTM.create_element("div", Dict("class" => "fruit")) |> r == "<div class=\"fruit\"></div>"
+        @test HTM.create_element("div", Dict("class" => "fruit"), "Hi!") |> r == "<div class=\"fruit\">Hi&#33;</div>"
+        @test HTM.create_element("div", Dict("class" => "fruit"), "Hi ", "there!") |> r == "<div class=\"fruit\">Hi there&#33;</div>"
 
-        @test create_element("button", Dict("class" => "fruit", "disabled" => nothing)) |> r == "<button class=\"fruit\" disabled></button>"
-        @test create_element("button", Dict("class" => "fruit", "disabled" => nothing), "Click me") |> r == "<button class=\"fruit\" disabled>Click me</button>"
+        @test HTM.create_element("button", Dict("class" => "fruit", "disabled" => nothing)) |> r == "<button class=\"fruit\" disabled></button>"
+        @test HTM.create_element("button", Dict("class" => "fruit", "disabled" => nothing), "Click me") |> r == "<button class=\"fruit\" disabled>Click me</button>"
 
-        @test create_element("circle", Dict("fill" => "orange")) |> r == "<circle fill=\"orange\" />"
+        @test HTM.create_element("circle", Dict("fill" => "orange")) |> r == "<circle fill=\"orange\" />"
     end
 
     @testset "Internal representation" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,7 +60,7 @@ const r = Hyperscript.render
 
         @testset "Styles" begin
             style = Dict("background" => "orange")
-            @test htm"<span style=$(style)>pineapple</span>" |> r == "<span style=\"background:orange\">pineapple</span>"
+            @test htm"<span style=$(style)>pineapple</span>" |> r == "<span style=\"background:orange;\">pineapple</span>"
         end
 
         @testset "Classes" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,8 +61,11 @@ const r = Hyperscript.render
             @test htm"<div>🍍<//>" |> r == "<div>🍍</div>"
         end
 
-        @testset "Support for HTML-style comments" begin
-            @test_skip htm"<div><!-- comment --></div>" |> r == "<div><!-- comment --></div>"
+        @testset "HTML-style comments" begin
+            @test htm"<!-- 🍌 -->" === nothing
+            @test htm"<!-- 🍌 --><div></div>" |> r == "<div></div>"
+            @test htm"<div></div><!-- 🍌 -->" |> r == "<div></div>"
+            @test htm"<div><!-- 🍌 --></div>" |> r == "<div></div>"
         end
 
         @testset "Styles" begin


### PR DESCRIPTION
- [x] Join classes when `AbstractVector` (#9)
- [x] Documentation: working together with Markdown and HTML from the standard library
  - [x] Comment about HTML entities (#23)
- [x] Ignore booleans (#24)
- [x] Ignore HTML comments (#2, #11)
- [x] Reimplement more performant, more general spread attributes with predictable precedence (#2, #18, #20, #25)
- [x] Review docs
  - [x] `usage.md`
  - [x] Feature descriptions
    - [x] Feature benchmarks
  - [x] Intenal links